### PR TITLE
Hotfix: Browser Share Dialog: Facebook composer not open for photo re…

### DIFF
--- a/FBSDKShareKit/FBSDKShareKit/Internal/_ShareUtility.swift
+++ b/FBSDKShareKit/FBSDKShareKit/Internal/_ShareUtility.swift
@@ -151,6 +151,8 @@ extension _ShareUtility: ShareUtilityProtocol {
 
       if let tags = buildWebShareTags(peopleIDs: content.peopleIDs) {
         parameters["tags"] = tags
+      } else {
+        parameters.removeValue(forKey: "tags")
       }
 
       completion(true, ShareBridgeAPI.MethodName.share, parameters)


### PR DESCRIPTION
…lated option from browser share dialog

Summary:
We were sending `tags` with an empty array which was causing `tags` to be percentage-encoded with a `line feed` code:

`[Facebook](https://m.facebook.com/dialog/share?dataFailuresFatal=0&display=touch&media=%255B%2522fbstaging%253A%255C%252F%255C%252Fgraph.facebook.com%255C%252Fstaging_resources%255C%252FMDEzNDU5MTA0NjA3MzEwNTI6MTE2Nzc5ODY0Mg%253D%253D%2522%252C%2522fbstaging%253A%255C%252F%255C%252Fgraph.facebook.com%255C%252Fstaging_resources%255C%252FMDE3MTMyNTg3NTY1MjA4MTA6MTc2OTM3MDcxMQ%253D%253D%2522%255D&redirect_uri=fb421415891237674%253A%252F%252Fbridge%252Fshare%253Fbridge_args%253D%25257B%252522action_id%252522%25253A%2525226FB4FBC8-28D1 (https://github.com/facebook/facebook-ios-sdk/commit/f26efad6e3759cc0a555918a622e4f09b9dac338)-4DB6-A926-637D91ED1 (https://github.com/facebook/facebook-ios-sdk/commit/f26efad6e3759cc0a555918a622e4f09b9dac338)EC9%252522%25257D&shareUUID=D05F2867-8F9D-48F2-BDF5-66A1D38590D2 (https://github.com/facebook/facebook-ios-sdk/commit/75876fd3bfbd45da6b462f56af6870038c83df33)&tags=(%0A))`

which in turn was causing `NSURL` to not build a url properly, thus browser was not opening the url. This fixes it and opens browser properly with photos to share.

{F725433582}

{F725433583}

Reviewed By: samodom

Differential Revision: D35864798

fbshipit-source-id: 9477d71b1356fc7aa67f50631adedd762430daa0

Thanks for proposing a pull # Google App Engine generated folder
appengine-generated/
To help us review the request, please complete the following:

- [ ] sign [contributor license agreement](https://code.facebook.com/cla)
- [ ] I've ensured that all existing tests pass and added tests (when/where necessary)
- [ ] I've updated the documentation (when/where necessary) and [Changelog](CHANGELOG.md) (when/where necessary)
- [ ] I've added the proper label to this pull request (e.g. `bug` for bug fixes)

## Pull Request Details

Describe what you accomplished in this pull request (for example, what happens before the change, and after the change)

## Test Plan

Test Plan: **Add your test plan here**
